### PR TITLE
fix: Change HTTP JSON username to email

### DIFF
--- a/lib/http_handler.dart
+++ b/lib/http_handler.dart
@@ -1,12 +1,12 @@
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
-
-class HTTPManager{
+class HTTPManager {
   HTTPManager();
 
-  static Future<bool> postLoginCredentials(String username, String password ) async {
-    var data={'username' : username, 'hashed_password': password};
+  static Future<bool> postLoginCredentials(
+      String username, String password) async {
+    var data = {'email': username, 'hashed_password': password};
     final response = await http.post(
       Uri.parse('http://164.92.183.156:80/authentication/credentials'),
       body: jsonEncode(data),
@@ -18,6 +18,4 @@ class HTTPManager{
       throw Exception('Login Credentials incorrect');
     }
   }
-
 }
-


### PR DESCRIPTION
Yeah I broke it on the backend sorry. Changed the accepted JSON from username to email because reasons. So here's a hotfix to fix that for our demo.